### PR TITLE
Add local SDR integration to flight tracker

### DIFF
--- a/flight_tracker_mcp/__init__.py
+++ b/flight_tracker_mcp/__init__.py
@@ -4,12 +4,15 @@ Enhanced Flight Tracker MCP Server
 Supports multiple flight tracking operations using OpenSky Network API
 """
 
+import argparse
 import asyncio
 import json
 import math
+import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import aiohttp
 from opensky_api import OpenSkyApi
 from mcp.server.stdio import stdio_server
 import mcp.types as types
@@ -17,16 +20,95 @@ from mcp.server import NotificationOptions, Server, InitializationOptions
 
 
 class FlightTracker:
-    """Enhanced flight tracking functionality using OpenSky Network API"""
+    """Enhanced flight tracking functionality using OpenSky Network and local SDR data"""
     
     def __init__(
         self,
         username: Optional[str] = None,
-        password: Optional[str] = None
+        password: Optional[str] = None,
+        local_url: Optional[str] = None,
+        receiver_lat: Optional[float] = None,
+        receiver_lon: Optional[float] = None
     ):
         self.api = OpenSkyApi(username=username, password=password)
         self.username = username
         self.password = password
+        self.local_url = local_url
+        self.receiver_lat = receiver_lat
+        self.receiver_lon = receiver_lon
+
+    async def _fetch_local_data(self) -> List[Dict[str, Any]]:
+        """Fetch flight data from local dump1090/readsb receiver"""
+        if not self.local_url:
+            return []
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(self.local_url) as response:
+                    if response.status != 200:
+                        return []
+                    data = await response.json()
+
+                    # Support standard dump1090/readsb aircraft.json format
+                    aircraft_list = data.get("aircraft", [])
+                    now = data.get("now", time.time())
+
+                    flights = []
+                    for a in aircraft_list:
+                        icao24 = a.get("hex", "").lower()
+                        if not icao24:
+                            continue
+
+                        # Convert altitude from feet to meters
+                        alt_ft = a.get("alt_baro") or a.get("alt_geom")
+                        alt_m = alt_ft * 0.3048 if alt_ft is not None else None
+
+                        # Convert speed from knots to m/s
+                        gs_kt = a.get("gs")
+                        gs_mps = gs_kt * 0.514444 if gs_kt is not None else None
+
+                        flights.append({
+                            "icao24": icao24,
+                            "callsign": a.get("flight", "").strip() or None,
+                            "latitude": a.get("lat"),
+                            "longitude": a.get("lon"),
+                            "geo_altitude_m": alt_m,
+                            "velocity_mps": gs_mps,
+                            "heading": a.get("track"),
+                            "last_contact": int(now - a.get("seen", 0)),
+                            "source": "local",
+                            # Additional fields from local radio
+                            "registration": a.get("r"),
+                            "type": a.get("t"),
+                            "squawk": a.get("squawk"),
+                        })
+                    return flights
+        except Exception:
+            return []
+
+    def _merge_flights(
+        self,
+        opensky_flights: List[Dict[str, Any]],
+        local_flights: List[Dict[str, Any]],
+        priority: str = "local"
+    ) -> List[Dict[str, Any]]:
+        """Merge flights from multiple sources, prioritizing one over the other"""
+        merged = {f["icao24"]: f for f in opensky_flights}
+
+        for lf in local_flights:
+            icao = lf["icao24"]
+            if priority == "local" or icao not in merged:
+                # If local priority or not in OpenSky, use local
+                # But we might want to keep some OpenSky info if it's missing in local
+                if icao in merged and priority == "local":
+                    # Keep origin country from OpenSky if available
+                    lf["origin_country"] = merged[icao].get("origin_country")
+                merged[icao] = lf
+            else:
+                # OpenSky priority and already in merged, do nothing unless we want to augment
+                pass
+
+        return list(merged.values())
 
     def _haversine_distance(
         self, lat1: float, lon1: float, lat2: float, lon2: float
@@ -55,38 +137,60 @@ class FlightTracker:
             lon + lon_delta,
         )
 
-    def get_overhead_flights(
-        self, lat: float, lon: float, radius_km: float = 10
+    async def get_overhead_flights(
+        self,
+        lat: float,
+        lon: float,
+        radius_km: float = 10,
+        source: str = "opensky"
     ) -> List[Dict[str, Any]]:
-        lamin, lamax, lomin, lomax = self._get_bounding_box(lat, lon, radius_km)
-        states = self.api.get_states(bbox=(lamin, lamax, lomin, lomax))
+        opensky_flights = []
+        local_flights = []
         
-        if not states or not states.states:
-            return []
+        if source in ["opensky", "merged"]:
+            lamin, lamax, lomin, lomax = self._get_bounding_box(lat, lon, radius_km)
+            # OpenSky API call is blocking, but we'll treat it as such for now
+            # In a production environment, we might use run_in_executor
+            states = self.api.get_states(bbox=(lamin, lamax, lomin, lomax))
+            if states and states.states:
+                for s in states.states:
+                    if s.latitude is None or s.longitude is None:
+                        continue
+                    distance = self._haversine_distance(lat, lon, s.latitude, s.longitude)
+                    if distance > radius_km:
+                        continue
+                    opensky_flights.append({
+                        "icao24": s.icao24,
+                        "callsign": s.callsign.strip() if s.callsign else None,
+                        "origin_country": s.origin_country,
+                        "latitude": s.latitude,
+                        "longitude": s.longitude,
+                        "geo_altitude_m": s.geo_altitude,
+                        "velocity_mps": s.velocity,
+                        "heading": s.true_track,
+                        "distance_km": distance,
+                        "last_contact": s.last_contact,
+                        "source": "opensky"
+                    })
 
-        flights = []
-        for s in states.states:
-            if s.latitude is None or s.longitude is None:
-                continue
+        if source in ["local", "merged"]:
+            all_local = await self._fetch_local_data()
+            for f in all_local:
+                if f["latitude"] is None or f["longitude"] is None:
+                    continue
+                distance = self._haversine_distance(lat, lon, f["latitude"], f["longitude"])
+                if distance <= radius_km:
+                    f["distance_km"] = distance
+                    local_flights.append(f)
 
-            distance = self._haversine_distance(lat, lon, s.latitude, s.longitude)
-            if distance > radius_km:
-                continue
+        if source == "merged":
+            flights = self._merge_flights(opensky_flights, local_flights)
+        elif source == "local":
+            flights = local_flights
+        else:
+            flights = opensky_flights
             
-            flights.append({
-                "icao24": s.icao24,
-                "callsign": s.callsign.strip() if s.callsign else None,
-                "origin_country": s.origin_country,
-                "latitude": s.latitude,
-                "longitude": s.longitude,
-                "geo_altitude_m": s.geo_altitude,
-                "velocity_mps": s.velocity,
-                "heading": s.true_track,
-                "distance_km": distance,
-                "last_contact": s.last_contact,
-            })
-            
-        flights.sort(key=lambda x: x["distance_km"])
+        flights.sort(key=lambda x: x.get("distance_km", float('inf')))
         return flights
 
     def get_my_states(self) -> List[Dict[str, Any]]:
@@ -110,28 +214,47 @@ class FlightTracker:
             "last_contact": s.last_contact,
         } for s in states.states]
 
-    def get_states_in_bbox(
+    async def get_states_in_bbox(
         self, 
         min_lat: float, 
         max_lat: float, 
         min_lon: float, 
-        max_lon: float
+        max_lon: float,
+        source: str = "opensky"
     ) -> List[Dict[str, Any]]:
-        states = self.api.get_states(bbox=(min_lat, max_lat, min_lon, max_lon))
-        if not states or not states.states:
-            return []
+        opensky_flights = []
+        local_flights = []
         
-        return [{
-            "icao24": s.icao24,
-            "callsign": s.callsign.strip() if s.callsign else None,
-            "origin_country": s.origin_country,
-            "latitude": s.latitude,
-            "longitude": s.longitude,
-            "geo_altitude_m": s.geo_altitude,
-            "velocity_mps": s.velocity,
-            "heading": s.true_track,
-            "last_contact": s.last_contact,
-        } for s in states.states]
+        if source in ["opensky", "merged"]:
+            states = self.api.get_states(bbox=(min_lat, max_lat, min_lon, max_lon))
+            if states and states.states:
+                opensky_flights = [{
+                    "icao24": s.icao24,
+                    "callsign": s.callsign.strip() if s.callsign else None,
+                    "origin_country": s.origin_country,
+                    "latitude": s.latitude,
+                    "longitude": s.longitude,
+                    "geo_altitude_m": s.geo_altitude,
+                    "velocity_mps": s.velocity,
+                    "heading": s.true_track,
+                    "last_contact": s.last_contact,
+                    "source": "opensky"
+                } for s in states.states]
+
+        if source in ["local", "merged"]:
+            all_local = await self._fetch_local_data()
+            local_flights = [
+                f for f in all_local
+                if f["latitude"] is not None and f["longitude"] is not None and
+                min_lat <= f["latitude"] <= max_lat and
+                min_lon <= f["longitude"] <= max_lon
+            ]
+
+        if source == "merged":
+            return self._merge_flights(opensky_flights, local_flights)
+        elif source == "local":
+            return local_flights
+        return opensky_flights
 
     def get_flights_in_interval(
         self, 
@@ -191,9 +314,9 @@ class FlightTracker:
         }
 
 
-# Create server and tracker instances
+# Create server instance
 server = Server("flight-tracker")
-tracker = FlightTracker()
+tracker: Optional[FlightTracker] = None
 
 
 @server.list_tools()
@@ -212,6 +335,12 @@ async def handle_list_tools() -> list[types.Tool]:
                         "type": "number", 
                         "description": "Search radius in km (default: 10)",
                         "default": 10
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["opensky", "local", "merged"],
+                        "description": "Data source to use (default: opensky)",
+                        "default": "opensky"
                     },
                 },
                 "required": ["latitude", "longitude"],
@@ -232,6 +361,12 @@ async def handle_list_tools() -> list[types.Tool]:
                     "max_lat": {"type": "number", "description": "Maximum latitude"},
                     "min_lon": {"type": "number", "description": "Minimum longitude"},
                     "max_lon": {"type": "number", "description": "Maximum longitude"},
+                    "source": {
+                        "type": "string",
+                        "enum": ["opensky", "local", "merged"],
+                        "description": "Data source to use (default: opensky)",
+                        "default": "opensky"
+                    },
                 },
                 "required": ["min_lat", "max_lat", "min_lon", "max_lon"],
             },
@@ -320,7 +455,8 @@ async def handle_call_tool(
             lat = arguments["latitude"]
             lon = arguments["longitude"]
             radius = arguments.get("radius_km", 10)
-            flights = tracker.get_overhead_flights(lat, lon, radius)
+            source = arguments.get("source", "opensky")
+            flights = await tracker.get_overhead_flights(lat, lon, radius, source)
             text = json.dumps(flights, indent=2) if flights else "No flights found"
             
         # User's receiver states (requires auth)
@@ -330,11 +466,13 @@ async def handle_call_tool(
         
         # States in bounding box
         elif name == "get_states_in_bbox":
-            states = tracker.get_states_in_bbox(
+            source = arguments.get("source", "opensky")
+            states = await tracker.get_states_in_bbox(
                 arguments["min_lat"],
                 arguments["max_lat"],
                 arguments["min_lon"],
                 arguments["max_lon"],
+                source
             )
             text = json.dumps(states, indent=2) if states else "No states in area"
         
@@ -393,8 +531,19 @@ async def handle_call_tool(
         )]
 
 
-async def main():
+async def main(
+    local_url: Optional[str] = None,
+    receiver_lat: Optional[float] = None,
+    receiver_lon: Optional[float] = None
+):
     """Run the enhanced MCP server"""
+    global tracker
+    tracker = FlightTracker(
+        local_url=local_url,
+        receiver_lat=receiver_lat,
+        receiver_lon=receiver_lon
+    )
+
     async with stdio_server() as (read_stream, write_stream):
         await server.run(
             read_stream,
@@ -407,7 +556,18 @@ async def main():
 
 def cli_main():
     """Entry point for the CLI command."""
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description="Flight Tracker MCP Server")
+    parser.add_argument("--local-url", help="URL for dump1090/readsb aircraft.json")
+    parser.add_argument("--receiver-lat", type=float, help="Latitude of the local receiver")
+    parser.add_argument("--receiver-lon", type=float, help="Longitude of the local receiver")
+
+    args = parser.parse_args()
+
+    asyncio.run(main(
+        local_url=args.local_url,
+        receiver_lat=args.receiver_lat,
+        receiver_lon=args.receiver_lon
+    ))
 
 if __name__ == "__main__":
     cli_main()


### PR DESCRIPTION
This change integrates local Software Defined Radio (SDR) data from dump1090 software into the flight tracker MCP server. It allows users to track flights using their own antenna as either an alternative to or alongside the OpenSky Network API. Key features include configurable local data endpoints, merging with local priority, and updated tool schemas for source selection.

---
*PR created automatically by Jules for task [10547500718527304458](https://jules.google.com/task/10547500718527304458) started by @GenAICPA*